### PR TITLE
Comment out unused parameters

### DIFF
--- a/boost/teamcity_boost.cpp
+++ b/boost/teamcity_boost.cpp
@@ -92,13 +92,13 @@ TeamcityBoostLogFormatter::TeamcityBoostLogFormatter()
 : flowId(getFlowIdFromEnvironment())
 {}
 
-void TeamcityBoostLogFormatter::log_start(ostream &out, counter_t test_cases_amount)
+void TeamcityBoostLogFormatter::log_start(ostream &/*out*/, counter_t /*test_cases_amount*/)
 {}
 
-void TeamcityBoostLogFormatter::log_finish(ostream &out)
+void TeamcityBoostLogFormatter::log_finish(ostream &/*out*/)
 {}
 
-void TeamcityBoostLogFormatter::log_build_info(ostream &out)
+void TeamcityBoostLogFormatter::log_build_info(ostream &/*out*/)
 {}
 
 void TeamcityBoostLogFormatter::test_unit_start(ostream &out, test_unit const& tu) {
@@ -134,7 +134,7 @@ void TeamcityBoostLogFormatter::test_unit_finish(ostream &out, test_unit const& 
     }
 }
 
-void TeamcityBoostLogFormatter::test_unit_skipped(ostream &out, test_unit const& tu)
+void TeamcityBoostLogFormatter::test_unit_skipped(ostream &/*out*/, test_unit const& /*tu*/)
 {}
 
 void TeamcityBoostLogFormatter::log_exception(ostream &out, log_checkpoint_data const &, const_string explanation) {
@@ -144,7 +144,7 @@ void TeamcityBoostLogFormatter::log_exception(ostream &out, log_checkpoint_data 
     currentDetails += what + "\n";
 }
 
-void TeamcityBoostLogFormatter::log_entry_start(ostream & out, log_entry_data const & entry_data, log_entry_types let)
+void TeamcityBoostLogFormatter::log_entry_start(ostream & out, log_entry_data const & entry_data, log_entry_types /*let*/)
 {
     stringstream ss;
 


### PR DESCRIPTION
We are using `-Werror` in our projects, so that unused parameters could fail a build.