### PR TITLE
take care about project version and make packages works again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,22 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(teamcity-cpp)
+if(CMAKE_VERSION VERSION_LESS 3.0)
+    project(teamcity-cpp)
+    # Old signature do not support VERSION, so set it manually
+    set(PROJECT_VERSION 1.5)
+else()
+    cmake_policy(SET CMP0048 NEW)
+    # C language needed for finding threads
+    # (will be fixed in cmake >= 3.4)
+    project(teamcity-cpp VERSION 1.5 LANGUAGES C CXX)
+endif()
+
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 find_package(Boost COMPONENTS unit_test_framework)
 find_package(GTest)
 find_package(CppUnit)
+find_package(Threads)
 
 include(RenderTestRunner)
 include(CTest)

--- a/gtest/CMakeLists.txt
+++ b/gtest/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package(Threads)
-
 add_executable(
     gtest_test
     gtest_test.cpp


### PR DESCRIPTION
`make package` now works again:

    zaufi@gentop〉/work/GitHub/teamcity-cpp〉git:cmakeify〉mkcd build && cmake .. && make -j8 && make test && make package
    -- The C compiler identification is GNU 4.9.3
    -- The CXX compiler identification is GNU 4.9.3
    -- Check for working C compiler: /usr/lib/outproc/bin/cc -- works
    -- Detecting C compiler ABI info - done
    -- Detecting C compile features - done
    -- Check for working CXX compiler: /usr/lib/outproc/bin/c++ -- works
    -- Detecting CXX compiler ABI info - done
    -- Detecting CXX compile features - done
    -- Boost version: 1.58.0
    -- Found the following Boost libraries:
    --   unit_test_framework
    -- Found GTest: /usr/lib64/libgtest.so  
    -- Found CPPUNIT: -L/usr/lib64 -lcppunit -ldl (found version "1.13.2") 
    -- Looking for include file pthread.h - found
    -- Looking for pthread_create - not found
    -- Looking for pthread_create in pthreads - not found
    -- Looking for pthread_create in pthread - found
    -- Found Threads: TRUE  
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /work/GitHub/teamcity-cpp/build
    Scanning dependencies of target common
    [ 10%] Building CXX object common/CMakeFiles/common.dir/teamcity_messages.cpp.o
    [ 10%] Built target common
    Scanning dependencies of target gtest_test
    Scanning dependencies of target cppunit_test
    [ 50%] Building CXX object cppunit/CMakeFiles/cppunit_test.dir/cppunit_test.cpp.o
    [ 50%] Building CXX object gtest/CMakeFiles/gtest_test.dir/teamcity_gtest.cpp.o
    [ 50%] Building CXX object gtest/CMakeFiles/gtest_test.dir/gtest_test.cpp.o
    [ 50%] Building CXX object cppunit/CMakeFiles/cppunit_test.dir/teamcity_cppunit.cpp.o
    Scanning dependencies of target boost_test
    [ 60%] Building CXX object boost/CMakeFiles/boost_test.dir/boost_test.cpp.o
    [ 70%] Building CXX object boost/CMakeFiles/boost_test.dir/teamcity_boost.cpp.o
    [ 80%] Linking CXX executable cppunit_test
    [ 80%] Built target cppunit_test
    [ 90%] Linking CXX executable gtest_test
    [ 90%] Built target gtest_test
    [100%] Linking CXX executable boost_test
    [100%] Built target boost_test
    Running tests...
    Test project /work/GitHub/teamcity-cpp/build
        Start 1: boost_test
    1/6 Test #1: boost_test .......................   Passed    0.06 sec
        Start 2: boost_test_flowid
    2/6 Test #2: boost_test_flowid ................   Passed    0.06 sec
        Start 3: gtest_test
    3/6 Test #3: gtest_test .......................   Passed    0.06 sec
        Start 4: gtest_test_flowid
    4/6 Test #4: gtest_test_flowid ................   Passed    0.06 sec
        Start 5: cppunit_test
    5/6 Test #5: cppunit_test .....................   Passed    0.06 sec
        Start 6: cppunit_test_flowid
    6/6 Test #6: cppunit_test_flowid ..............   Passed    0.06 sec

    100% tests passed, 0 tests failed out of 6

    Total Test time (real) =   0.37 sec
    [ 10%] Built target common
    [ 40%] Built target boost_test
    [ 70%] Built target gtest_test
    [100%] Built target cppunit_test
    Run CPack packaging tool...
    CPack: Create package using TBZ2
    CPack: Install projects
    CPack: - Run preinstall target for: teamcity-cpp
    CPack: - Install project: teamcity-cpp
    CPack: -   Install component: boost
    CPack: -   Install component: cppunit
    CPack: -   Install component: gtest
    CPack: Create package
    CPack: - package: /work/GitHub/teamcity-cpp/build/teamcity-cpp-1.5-boost.tar.bz2 generated.
    CPack: - package: /work/GitHub/teamcity-cpp/build/teamcity-cpp-1.5-cppunit.tar.bz2 generated.
    CPack: - package: /work/GitHub/teamcity-cpp/build/teamcity-cpp-1.5-gtest.tar.bz2 generated.
    zaufi@gentop〉…/GitHub/teamcity-cpp/build〉default〉pfx: /usr/local〉git:cmakeify〉

