### PR TITLE
Adds support for boost 1.59.0

### DIFF
--- a/common/teamcity_messages.cpp
+++ b/common/teamcity_messages.cpp
@@ -173,5 +173,16 @@ void TeamcityMessages::testIgnored(std::string name, std::string message, std::s
     closeMsg();
 }
 
+void TeamcityMessages::testOutput(std::string name, std::string output, std::string flowid, bool isStdError) {
+    openMsg(isStdError ? "testStdErr" : "testStdOut");
+    writeProperty("name", name);
+    writeProperty("out", output);
+    if(flowid.length() > 0) {
+        writeProperty("flowId", flowid);
+    }
+
+    closeMsg();
+}
+
 }
 }

--- a/common/teamcity_messages.h
+++ b/common/teamcity_messages.h
@@ -38,6 +38,9 @@ protected:
     void closeMsg();
 
 public:
+    static const bool StdErr = true;
+    static const bool StdOut = false;
+
     TeamcityMessages();
 
     void setOutput(std::ostream &);
@@ -48,6 +51,7 @@ public:
     void testStarted(std::string name, std::string flowid =  std::string(), bool captureStandardOutput = false);
     void testFailed(std::string name, std::string message, std::string details, std::string flowid =  std::string());
     void testIgnored(std::string name, std::string message, std::string flowid =  std::string());
+    void testOutput(std::string name, std::string output, std::string flowid, bool isStdErr = StdOut);
     void testFinished(std::string name, int durationMs = -1, std::string flowid = std::string());
 };
 


### PR DESCRIPTION
Based upon patch at https://github.com/mutanabbi/chewy-cmake-rep/commit/ca7221f916ce631dd14b3be81e2c8d6b4d57659e.  Fixes #10.  See also #13.

It is based off the latest master branch, and only contains the changes needed for making the code support boost 1.59.0.  

These changes will work for boost 1.59.0 - but not previous versions, since some variables and function signatures changed.  Probably the best solution would be to do some sort of condition, but I am not familiar enough with the boost::test library to suggest what condition to key off of (I literally just took the changes from the above patch and based them off the master branch)