### PR TITLE
Remove boost --log-level option overriding.

### DIFF
--- a/boost/teamcity_boost.cpp
+++ b/boost/teamcity_boost.cpp
@@ -90,7 +90,6 @@ struct TeamcityFormatterRegistrar {
     TeamcityFormatterRegistrar() {
         if (underTeamcity()) {
             boost::unit_test::unit_test_log.set_formatter(new TeamcityBoostLogFormatter());
-            boost::unit_test::unit_test_log.set_threshold_level(boost::unit_test::log_test_units);
         }
     }
 };


### PR DESCRIPTION
**Previous behavior:**
- the output behavior is different for Non-TC mode and TC mode: no any messages form test in console when TeamCity mode is enabled
- it's impossible to configure from command line and environment variables.

P.S. Default boost test output behavior shows only errors in console.
