### PR TITLE
support TeamcityFormatterRegistrar in static libs

### DIFF
--- a/boost/README.md
+++ b/boost/README.md
@@ -1,11 +1,11 @@
 Boost listener for TeamCity
 ---------------------------
 
-To report your test results to TeamCity server include teamcity_messages.* and teamcity_boost.cpp to your project.
+To report your test results to TeamCity server include teamcity_messages.* and teamcity_boost.* to your project.
 
-teamcity_boost.cpp register global fixture
+teamcity_boost.cpp registers global fixture
 ( http://www.boost.org/doc/libs/1_38_0/libs/test/doc/html/utf/user-guide/fixture/global.html )
-to replace output formatter if run under TeamCity.
+to replace output formatter if run under TeamCity. If you prefer to place teamcity_boost.cpp in a static library, then you'll need to enable teamcity fixture by calling `jetbrains::teamcity::TeamcityGlobalFixture()` from your code.
 
 If you have tests with test parameters, see PARAM_TEST_CASES.txt for quick solution.
 

--- a/boost/teamcity_boost.cpp
+++ b/boost/teamcity_boost.cpp
@@ -97,6 +97,8 @@ struct TeamcityFormatterRegistrar {
 
 BOOST_GLOBAL_FIXTURE(TeamcityFormatterRegistrar);
 
+void TeamcityGlobalFixture(){}
+
 // Formatter implementation
 static std::string toString(boost::unit_test::const_string bstr) {
     std::stringstream ss;

--- a/boost/teamcity_boost.h
+++ b/boost/teamcity_boost.h
@@ -1,0 +1,8 @@
+#ifndef H_TEAMCITY_BOOST
+#define H_TEAMCITY_BOOST
+
+namespace jetbrains { namespace teamcity {
+    void TeamcityGlobalFixture();
+}}
+
+#endif /* H_TEAMCITY_BOOST */


### PR DESCRIPTION
The way it is now you broke existing teamcity integration with projects that use teamcity code in a static library. Since you made TeamcityFormatterRegistrar private to teamcity_boost.cpp now we cannot register teamcity fixture. You register teamcity fixture inside teamcity_boost.cpp but that has no effect since this whole file becomes unused if it's part of static library. ANd all our projects use it from a static library.

I added `jetbrains::teamcity::TeamcityGlobalFixture();` function, and when that function is used from final binary it triggers linker to include teamcity_boost.obj which registers teamcity fixture.